### PR TITLE
filePath.toAbsolutePath() -> filePath

### DIFF
--- a/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/DiskAnn.java
+++ b/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/DiskAnn.java
@@ -120,7 +120,7 @@ public class DiskAnn {
         var dataFile = System.getenv("DATA_FILE_WITH_VECTORS");
         var filePath = Path.of(dataFile);
 
-        System.out.println("Reading JSON file from " + filePath.toAbsolutePath());
+        System.out.println("Reading JSON file from " + filePath);
         var jsonContent = Files.readString(filePath);
 
         return jsonMapper.readValue(jsonContent, new TypeReference<List<Map<String, Object>>>() {});

--- a/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/HNSW.java
+++ b/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/HNSW.java
@@ -120,7 +120,7 @@ public class HNSW {
         var dataFile = System.getenv("DATA_FILE_WITH_VECTORS");
         var filePath = Path.of(dataFile);
 
-        System.out.println("Reading JSON file from " + filePath.toAbsolutePath());
+        System.out.println("Reading JSON file from " + filePath);
         var jsonContent = Files.readString(filePath);
 
         return jsonMapper.readValue(jsonContent, new TypeReference<List<Map<String, Object>>>() {});

--- a/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/IVF.java
+++ b/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/IVF.java
@@ -120,7 +120,7 @@ public class IVF {
         var dataFile = System.getenv("DATA_FILE_WITH_VECTORS");
         var filePath = Path.of(dataFile);
 
-        System.out.println("Reading JSON file from " + filePath.toAbsolutePath());
+        System.out.println("Reading JSON file from " + filePath);
         var jsonContent = Files.readString(filePath);
 
         return jsonMapper.readValue(jsonContent, new TypeReference<List<Map<String, Object>>>() {});


### PR DESCRIPTION
Using `toAbsolutePath()` results in slightly awkward output:
- contains irrelevant local details like username and path specifics
- the `..` parent-folder syntax is not resolved correctly into a clear, full path

