### PR TITLE
Add CI validation workflows for infrastructure and samples

### DIFF
--- a/.github/workflows/validate-infra.yml
+++ b/.github/workflows/validate-infra.yml
@@ -4,24 +4,31 @@ on:
   pull_request:
     paths:
       - 'infra/**'
+      - '.github/workflows/validate-infra.yml'
   push:
     branches:
       - main
     paths:
       - 'infra/**'
+      - '.github/workflows/validate-infra.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate-bicep:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Validate Bicep compilation
+      - name: Validate Bicep
         run: |
+          az bicep build --file infra/main.bicep
           az bicep build-params --file infra/main.bicepparam
-      
-      - name: Lint Bicep
-        run: |
-          az bicep lint --file infra/main.bicep

--- a/.github/workflows/validate-infra.yml
+++ b/.github/workflows/validate-infra.yml
@@ -18,18 +18,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Install Azure CLI
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-        continue-on-error: true
-      
-      - name: Setup Azure CLI (fallback)
-        if: steps.login.outcome == 'failure'
-        run: |
-          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-      
       - name: Validate Bicep compilation
         run: |
           az bicep build-params --file infra/main.bicepparam
+      
+      - name: Lint Bicep
+        run: |
           az bicep lint --file infra/main.bicep

--- a/.github/workflows/validate-infra.yml
+++ b/.github/workflows/validate-infra.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Validate Bicep
         run: |

--- a/.github/workflows/validate-infra.yml
+++ b/.github/workflows/validate-infra.yml
@@ -1,0 +1,35 @@
+name: Validate Infrastructure
+
+on:
+  pull_request:
+    paths:
+      - 'infra/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'infra/**'
+
+jobs:
+  validate-bicep:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Install Azure CLI
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+        continue-on-error: true
+      
+      - name: Setup Azure CLI (fallback)
+        if: steps.login.outcome == 'failure'
+        run: |
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      
+      - name: Validate Bicep compilation
+        run: |
+          az bicep build-params --file infra/main.bicepparam
+          az bicep lint --file infra/main.bicep

--- a/.github/workflows/validate-samples.yml
+++ b/.github/workflows/validate-samples.yml
@@ -1,0 +1,120 @@
+name: Validate Samples
+
+on:
+  pull_request:
+    paths:
+      - 'ai/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'ai/**'
+
+jobs:
+  validate-typescript:
+    name: TypeScript - ${{ matrix.sample }}
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      matrix:
+        sample:
+          - vector-search-typescript
+          - vector-search-agent-typescript
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ai/${{ matrix.sample }}/package-lock.json
+      
+      - name: Install dependencies
+        working-directory: ai/${{ matrix.sample }}
+        run: npm ci
+      
+      - name: Build TypeScript
+        working-directory: ai/${{ matrix.sample }}
+        run: npm run build
+
+  validate-dotnet:
+    name: .NET
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      
+      - name: Build solution
+        run: dotnet build documentdb-samples.sln
+
+  validate-go:
+    name: Go - ${{ matrix.sample }}
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      matrix:
+        sample:
+          - vector-search-go
+          - vector-search-agent-go
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: ai/${{ matrix.sample }}/go.sum
+      
+      - name: Build Go
+        working-directory: ai/${{ matrix.sample }}
+        run: go build ./...
+
+  validate-python:
+    name: Python
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install dependencies
+        working-directory: ai/vector-search-python
+        run: pip install -r requirements.txt
+
+  validate-java:
+    name: Java
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      
+      - name: Compile Java
+        working-directory: ai/vector-search-java
+        run: mvn compile -DskipTests

--- a/.github/workflows/validate-samples.yml
+++ b/.github/workflows/validate-samples.yml
@@ -34,10 +34,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -59,7 +59,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -83,10 +83,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
           cache-dependency-path: ai/${{ matrix.sample }}/go.sum
@@ -103,10 +103,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       
@@ -127,7 +127,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/validate-samples.yml
+++ b/.github/workflows/validate-samples.yml
@@ -93,7 +93,7 @@ jobs:
       
       - name: Build Go
         working-directory: ai/${{ matrix.sample }}
-        run: go build ./...
+        run: go build -o /dev/null ./...
 
   validate-python:
     name: Python
@@ -117,7 +117,7 @@ jobs:
       - name: Validate Python syntax
         working-directory: ai/vector-search-python
         run: |
-          python -m py_compile *.py
+          find . -name "*.py" -exec python -m py_compile {} +
 
   validate-java:
     name: Java

--- a/.github/workflows/validate-samples.yml
+++ b/.github/workflows/validate-samples.yml
@@ -4,18 +4,29 @@ on:
   pull_request:
     paths:
       - 'ai/**'
+      - '.github/workflows/validate-samples.yml'
   push:
     branches:
       - main
     paths:
       - 'ai/**'
+      - '.github/workflows/validate-samples.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate-typescript:
     name: TypeScript - ${{ matrix.sample }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     continue-on-error: false
     strategy:
+      fail-fast: false
       matrix:
         sample:
           - vector-search-typescript
@@ -43,6 +54,7 @@ jobs:
   validate-dotnet:
     name: .NET
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     continue-on-error: false
     
     steps:
@@ -60,8 +72,10 @@ jobs:
   validate-go:
     name: Go - ${{ matrix.sample }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     continue-on-error: false
     strategy:
+      fail-fast: false
       matrix:
         sample:
           - vector-search-go
@@ -84,6 +98,7 @@ jobs:
   validate-python:
     name: Python
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     continue-on-error: false
     
     steps:
@@ -98,10 +113,16 @@ jobs:
       - name: Install dependencies
         working-directory: ai/vector-search-python
         run: pip install -r requirements.txt
+      
+      - name: Validate Python syntax
+        working-directory: ai/vector-search-python
+        run: |
+          python -m py_compile *.py
 
   validate-java:
     name: Java
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     continue-on-error: false
     
     steps:

--- a/.github/workflows/validate-samples.yml
+++ b/.github/workflows/validate-samples.yml
@@ -91,9 +91,19 @@ jobs:
           go-version: '1.24'
           cache-dependency-path: ai/${{ matrix.sample }}/go.sum
       
-      - name: Build Go
+      - name: Validate Go
         working-directory: ai/${{ matrix.sample }}
-        run: go build -o /dev/null ./...
+        run: |
+          # Check if src/ has multiple main() declarations (independent programs sharing utils)
+          if [ -d "src" ] && [ "$(grep -rl '^func main()' src/*.go 2>/dev/null | wc -l)" -gt 1 ]; then
+            cd src
+            for f in $(grep -l '^func main()' *.go); do
+              echo "Building $f + utils.go"
+              go build -o /dev/null "$f" utils.go
+            done
+          else
+            go build ./...
+          fi
 
   validate-python:
     name: Python


### PR DESCRIPTION
This PR adds two GitHub Actions workflows to validate infrastructure and sample code:

## 🔧 validate-infra.yml
- Triggers on PRs and pushes to main affecting infra/**
- Validates Bicep compilation using z bicep build-params and z bicep lint
- Ensures infrastructure code compiles without errors

## 🏗️ validate-samples.yml
- Triggers on PRs and pushes to main affecting i/**
- Uses matrix strategy to validate each language/sample independently:
  - **TypeScript** (2 samples): npm ci + build using tsc
  - **.NET**: dotnet build on documentdb-samples.sln
  - **Go** (2 samples): go build on each module (using Go 1.24)
  - **Python**: pip install to validate dependencies
  - **Java**: mvn compile using JDK 21

All jobs fail fast (continue-on-error: false) to ensure any broken sample is immediately visible. Each sample runs in its own job for clear failure isolation.