### PR TITLE
fix: drop collections at end of each sample

### DIFF
--- a/ai/vector-search-dotnet/Services/VectorSearchService.cs
+++ b/ai/vector-search-dotnet/Services/VectorSearchService.cs
@@ -131,6 +131,10 @@ public class VectorSearchService
                     _logger.LogInformation($"  {i + 1}. {hotelName} (Similarity: {result.Score:F4})");
                 }
             }
+
+            // Drop the collection
+            await _mongoService.DropCollectionAsync(_config.VectorSearch.DatabaseName, collectionName);
+            _logger.LogInformation($"Dropped collection: {collectionName}");
         }
         catch (Exception ex)
         {

--- a/ai/vector-search-go/src/diskann.go
+++ b/ai/vector-search-go/src/diskann.go
@@ -227,5 +227,11 @@ func main() {
 	// Display results
 	PrintSearchResults(results, 5, true)
 
+	// Drop the collection
+	if err := collection.Drop(ctx); err != nil {
+		log.Printf("Warning: Failed to drop collection: %v", err)
+	}
+	fmt.Println("Dropped collection: hotels_diskann")
+
 	fmt.Println("\nDiskANN demonstration completed successfully!")
 }

--- a/ai/vector-search-go/src/hnsw.go
+++ b/ai/vector-search-go/src/hnsw.go
@@ -230,5 +230,11 @@ func main() {
 	// Display the search results
 	PrintSearchResults(results, 5, true)
 
+	// Drop the collection
+	if err := collection.Drop(ctx); err != nil {
+		log.Printf("Warning: Failed to drop collection: %v", err)
+	}
+	fmt.Println("Dropped collection: hotels_hnsw")
+
 	fmt.Println("\nHNSW demonstration completed successfully!")
 }

--- a/ai/vector-search-go/src/ivf.go
+++ b/ai/vector-search-go/src/ivf.go
@@ -227,5 +227,11 @@ func main() {
 	// Display the search results
 	PrintSearchResults(results, 5, true)
 
+	// Drop the collection
+	if err := collection.Drop(ctx); err != nil {
+		log.Printf("Warning: Failed to drop collection: %v", err)
+	}
+	fmt.Println("Dropped collection: hotels_ivf")
+
 	fmt.Println("\nIVF demonstration completed successfully!")
 }

--- a/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/DiskAnn.java
+++ b/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/DiskAnn.java
@@ -66,6 +66,10 @@ public class DiskAnn {
             var queryEmbedding = createEmbedding(openAIClient, SAMPLE_QUERY);
             performVectorSearch(collection, queryEmbedding);
 
+            // Drop the collection
+            collection.drop();
+            System.out.println("Dropped collection: " + COLLECTION_NAME);
+
         } catch (Exception e) {
             System.err.println("Error: " + e.getMessage());
             e.printStackTrace();

--- a/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/HNSW.java
+++ b/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/HNSW.java
@@ -66,6 +66,10 @@ public class HNSW {
             var queryEmbedding = createEmbedding(openAIClient, SAMPLE_QUERY);
             performVectorSearch(collection, queryEmbedding);
 
+            // Drop the collection
+            collection.drop();
+            System.out.println("Dropped collection: " + COLLECTION_NAME);
+
         } catch (Exception e) {
             System.err.println("Error: " + e.getMessage());
             e.printStackTrace();

--- a/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/IVF.java
+++ b/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/IVF.java
@@ -66,6 +66,10 @@ public class IVF {
             var queryEmbedding = createEmbedding(openAIClient, SAMPLE_QUERY);
             performVectorSearch(collection, queryEmbedding);
 
+            // Drop the collection
+            collection.drop();
+            System.out.println("Dropped collection: " + COLLECTION_NAME);
+
         } catch (Exception e) {
             System.err.println("Error: " + e.getMessage());
             e.printStackTrace();

--- a/ai/vector-search-python/src/diskann.py
+++ b/ai/vector-search-python/src/diskann.py
@@ -200,8 +200,10 @@ def main():
         raise
 
     finally:
-        # Close the MongoDB client
+        # Drop the collection and close connection
         if 'mongo_client' in locals():
+            mongo_client[config['database_name']].drop_collection(config['collection_name'])
+            print(f"Dropped collection: {config['collection_name']}")
             mongo_client.close()
 
 

--- a/ai/vector-search-python/src/hnsw.py
+++ b/ai/vector-search-python/src/hnsw.py
@@ -196,8 +196,10 @@ def main():
         raise
 
     finally:
-        # Clean up MongoDB connection
+        # Drop the collection and close connection
         if 'mongo_client' in locals():
+            mongo_client[config['database_name']].drop_collection(config['collection_name'])
+            print(f"Dropped collection: {config['collection_name']}")
             mongo_client.close()
 
 

--- a/ai/vector-search-python/src/ivf.py
+++ b/ai/vector-search-python/src/ivf.py
@@ -191,8 +191,10 @@ def main():
         raise
 
     finally:
-        # Ensure MongoDB connection is properly closed
+        # Drop the collection and close connection
         if 'mongo_client' in locals():
+            mongo_client[config['database_name']].drop_collection(config['collection_name'])
+            print(f"Dropped collection: {config['collection_name']}")
             mongo_client.close()
 
 

--- a/ai/vector-search-typescript/src/diskann.ts
+++ b/ai/vector-search-typescript/src/diskann.ts
@@ -95,9 +95,13 @@ async function main() {
         console.error('App failed:', error);
         process.exitCode = 1;
     } finally {
-        console.log('Closing database connection...');
-        if (dbClient) await dbClient.close();
-        console.log('Database connection closed');
+        if (dbClient) {
+            const db = dbClient.db(config.dbName);
+            await db.dropCollection(config.collectionName);
+            console.log('Dropped collection:', config.collectionName);
+            await dbClient.close();
+            console.log('Database connection closed');
+        }
     }
 }
 

--- a/ai/vector-search-typescript/src/hnsw.ts
+++ b/ai/vector-search-typescript/src/hnsw.ts
@@ -95,9 +95,13 @@ async function main() {
         console.error('App failed:', error);
         process.exitCode = 1;
     } finally {
-        console.log('Closing database connection...');
-        if (dbClient) await dbClient.close();
-        console.log('Database connection closed');
+        if (dbClient) {
+            const db = dbClient.db(config.dbName);
+            await db.dropCollection(config.collectionName);
+            console.log('Dropped collection:', config.collectionName);
+            await dbClient.close();
+            console.log('Database connection closed');
+        }
     }
 }
 

--- a/ai/vector-search-typescript/src/ivf.ts
+++ b/ai/vector-search-typescript/src/ivf.ts
@@ -96,9 +96,13 @@ async function main() {
         console.error('App failed:', error);
         process.exitCode = 1;
     } finally {
-        console.log('Closing database connection...');
-        if (dbClient) await dbClient.close();
-        console.log('Database connection closed');
+        if (dbClient) {
+            const db = dbClient.db(config.dbName);
+            await db.dropCollection(config.collectionName);
+            console.log('Dropped collection:', config.collectionName);
+            await dbClient.close();
+            console.log('Database connection closed');
+        }
     }
 }
 


### PR DESCRIPTION
Each vector search sample now drops its collection after the search completes, ensuring no leftover collections accumulate between runs.

**Changes (13 files):**
- **TypeScript** (ivf.ts, hnsw.ts, diskann.ts): Drop collection in finally block before closing connection
- **Python** (ivf.py, hnsw.py, diskann.py): Drop collection in finally block before closing connection
- **Go** (ivf.go, hnsw.go, diskann.go): Drop collection before final success message
- **Java** (IVF.java, HNSW.java, DiskAnn.java): Drop collection after vector search completes
- **.NET** (VectorSearchService.cs): Drop collection after printing search results

All changes are minimal — just adding the drop call at the appropriate cleanup point in each sample.