### PR TITLE
fix: add .global. to connection string hostname in vector-search TS + Java

### DIFF
--- a/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/DiskAnn.java
+++ b/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/DiskAnn.java
@@ -94,7 +94,7 @@ public class DiskAnn {
             .withMechanismProperty("OIDC_CALLBACK", callback);
 
         var connectionString = new ConnectionString(
-            String.format("mongodb+srv://%s@%s.mongocluster.cosmos.azure.com/?authMechanism=MONGODB-OIDC&tls=true&retrywrites=false&maxIdleTimeMS=120000",
+            String.format("mongodb+srv://%s@%s.global.mongocluster.cosmos.azure.com/?authMechanism=MONGODB-OIDC&tls=true&retrywrites=false&maxIdleTimeMS=120000",
                 managedIdentityPrincipalId, clusterName)
         );
 

--- a/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/HNSW.java
+++ b/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/HNSW.java
@@ -94,7 +94,7 @@ public class HNSW {
             .withMechanismProperty("OIDC_CALLBACK", callback);
 
         var connectionString = new ConnectionString(
-            String.format("mongodb+srv://%s@%s.mongocluster.cosmos.azure.com/?authMechanism=MONGODB-OIDC&tls=true&retrywrites=false&maxIdleTimeMS=120000",
+            String.format("mongodb+srv://%s@%s.global.mongocluster.cosmos.azure.com/?authMechanism=MONGODB-OIDC&tls=true&retrywrites=false&maxIdleTimeMS=120000",
                 managedIdentityPrincipalId, clusterName)
         );
 

--- a/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/IVF.java
+++ b/ai/vector-search-java/src/main/java/com/azure/documentdb/samples/IVF.java
@@ -94,7 +94,7 @@ public class IVF {
             .withMechanismProperty("OIDC_CALLBACK", callback);
 
         var connectionString = new ConnectionString(
-            String.format("mongodb+srv://%s@%s.mongocluster.cosmos.azure.com/?authMechanism=MONGODB-OIDC&tls=true&retrywrites=false&maxIdleTimeMS=120000",
+            String.format("mongodb+srv://%s@%s.global.mongocluster.cosmos.azure.com/?authMechanism=MONGODB-OIDC&tls=true&retrywrites=false&maxIdleTimeMS=120000",
                 managedIdentityPrincipalId, clusterName)
         );
 

--- a/ai/vector-search-typescript/src/utils.ts
+++ b/ai/vector-search-typescript/src/utils.ts
@@ -80,7 +80,7 @@ export function getClientsPasswordless(): { aiClient: AzureOpenAI | null; dbClie
     // For DocumentDB with DefaultAzureCredential (uses signed-in user)
     {
         dbClient = new MongoClient(
-            `mongodb+srv://${clusterName}.mongocluster.cosmos.azure.com/`, {
+            `mongodb+srv://${clusterName}.global.mongocluster.cosmos.azure.com/`, {
             connectTimeoutMS: 120000,
             tls: true,
             retryWrites: false,


### PR DESCRIPTION
Closes diberry/project-dina#256

## What
Adds \.global.\ to the DocumentDB connection string hostname in:
- vector-search-typescript/src/utils.ts
- vector-search-java IVF.java, HNSW.java, DiskAnn.java

## Why
Per Khelan Modi's guidance, all samples must use the global read-write endpoint format (\<cluster>.global.mongocluster.cosmos.azure.com\) to auto-follow active write region after replica promotion. Without \.global.\, connections silently become read-only after failover.

## Verification
Pattern matches vector-search-python, vector-search-go, vector-search-dotnet, and all select-algorithm samples.